### PR TITLE
Allow multiple ResponseGroups for a single request to be specified as an Array

### DIFF
--- a/lib/asin/client.rb
+++ b/lib/asin/client.rb
@@ -337,6 +337,8 @@ module ASIN
     def call(params)
       Configuration.validate_credentials!
 
+      params[:ResponseGroup] = params[:ResponseGroup].collect{|g| g.to_s.strip}.join(',') if !params[:ResponseGroup].nil? && params[:ResponseGroup].is_a?(Array)
+
       log(:debug, "calling with params=#{params}")
       signed = create_signed_query_string(params)
 

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -85,6 +85,19 @@ module ASIN
         end
       end
 
+      it "should lookup multiple response groups" do
+        VCR.use_cassette("lookup_#{ANY_ASIN}_small_and_alternateversions", :match_requests_on => [:host, :path]) do
+          items = @helper.lookup(ANY_ASIN, :ResponseGroup => [:Small, :AlternateVersions])
+
+          item = items.first
+          item.asin.should eql(ANY_ASIN)
+          item.title.should =~ /Learn Objective/
+          item.raw.include?("AlternateVersions").should eql(true)
+          item.raw["AlternateVersions"].length.should eql(1)
+          item.raw["AlternateVersions"]["AlternateVersion"]["Binding"].should eql("Kindle Edition")
+        end
+      end
+
       it "should lookup multiple books" do
         VCR.use_cassette("lookup_multiple_asins", :match_requests_on => [:host, :path]) do
           items = @helper.lookup(ANY_ASIN, ANY_OTHER_ASIN)


### PR DESCRIPTION
It seemed natural to me to specify multiple ResponseGroups like:

lookup "1430218150", :ResponseGroup => [:Small, :AlternateVersions]

This small patch checks if ResponseGroup is an array, and if it is, joins it and sends on to Amazon. Test case included.
