### PR TITLE
Added multiple ASIN lookup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ ASIN is designed as a module, so you can include it into any object you like:
     # lookup an ASIN
     lookup '1430218150'
 
+    # lookup multiple items by ASIN
+    lookup ['1430218150','1934356549']
+
 But you can also use the *instance* method to get a proxy-object:
 
     # just require


### PR DESCRIPTION
Just wanted to mention in the README that multiple ASINs can be looked up at once.

Also, in case you're curious, the second ASIN I added links to the book "Agile Web Development with Rails".
http://www.amazon.com/Agile-Development-Rails-Pragmatic-Programmers/dp/1934356549/ref=sr_1_1?ie=UTF8&qid=1360527054&sr=8-1&keywords=Agile+Web+Development+with+Rails
