### PR TITLE
updated lookup method in 0.8.0 branch

### DIFF
--- a/lib/asin/client.rb
+++ b/lib/asin/client.rb
@@ -149,8 +149,15 @@ module ASIN
     #
     #   lookup(asin, :ResponseGroup => [:Small, :AlternateVersions])
     #
+    # Because the default :idType is ASIN, you might optionally wish to
+    # search specifically for an ISBN. Note when you explicitly specify the
+    # idType you need to also specify the SearchIndex:
+    #
+    # lookup(asin, {:ResponseGroup => :Medium, :IdType => :ISBN, :SearchIndex => :Books})
+    #
     def lookup(*asins)
       params = asins.last.is_a?(Hash) ? asins.pop : {:ResponseGroup => :Medium}
+      params.merge(:idType => 'asin') unless params.has_key?(:IdType)
       response = call(params.merge(:Operation => :ItemLookup, :ItemId => asins.join(',')))
       arrayfy(response['ItemLookupResponse']['Items']['Item']).map {|item| handle_item(item)}
     end


### PR DESCRIPTION
The 2.0 release uses RashieMash and I am for some reason unable to get asin/adapter working in conjunction with the lookup method. For the time being I'll continue using the 0.8.0 branch and so thought I'd contribute this change in case other users still on this branch were interested. The addition makes it possible to use the lookup method in conjunction with the ISBN IdType, meaning users can query Amazon for book ISBNs instead of solely relying on the ASIN. My pull request is supposed to target the 0.8.0 branch specifically; this won't work of course with the 2.0 release.
