### PR TITLE
Use OpenSSL::Digest in place of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/asin/client.rb
+++ b/lib/asin/client.rb
@@ -8,7 +8,7 @@ require 'rash'
 module ASIN
   module Client
 
-    DIGEST  = OpenSSL::Digest::Digest.new('sha256')
+    DIGEST  = OpenSSL::Digest.new('sha256')
     PATH    = '/onca/xml'
 
     # Convenience method to create an ASIN client.


### PR DESCRIPTION
Deprecation. See here: https://github.com/ruby/ruby/pull/446
