### PR TITLE
adds snake_case_hash and uses Hashie::SCHash in place of Hashie::Rash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## No Version Tag
+
+* changes from Hashie::Rash to Hashie::SCHash, because Hashie added its own Rash class that conflicted with the Rash gem.
+
 ## 2.0.1
 
 * get rid of OpenSSL deprecation (davelacy) https://github.com/phoet/asin/pull/36

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       crack (>= 0.3)
       hashie (>= 1.1)
       httpi (>= 0.9)
-      rash (>= 0.4)
+      snake_case_hash (>= 1.0.2)
 
 GEM
   remote: http://rubygems.org/
@@ -24,15 +24,13 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    hashie (2.0.5)
+    hashie (3.4.3)
     httpclient (2.3.0.1)
-    httpi (2.3.0)
+    httpi (2.4.1)
       rack
     multi_json (1.10.0)
-    rack (1.5.2)
+    rack (1.6.4)
     rake (0.9.2.2)
-    rash (0.4.0)
-      hashie (~> 2.0.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -47,6 +45,8 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
+    snake_case_hash (1.0.2)
+      hashie (~> 3.0)
     vcr (2.2.5)
     webmock (1.8.11)
       addressable (>= 2.2.7)

--- a/asin.gemspec
+++ b/asin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('crack',     '>= 0.3')
   s.add_dependency('hashie',    '>= 1.1')
-  s.add_dependency('rash',      '>= 0.4')
+  s.add_dependency('snake_case_hash',      '>= 1.0.2')
   s.add_dependency('httpi',     '>= 0.9')
   s.add_dependency('confiture', '>= 0.1')
 

--- a/lib/asin/adapter.rb
+++ b/lib/asin/adapter.rb
@@ -1,8 +1,8 @@
 module ASIN
   module Adapter
     def handle_type(data, type)
-      Hashie::Rash.new(data).tap do |rash|
-        rash.instance_eval do
+      Hashie::SCHash.new(data).tap do |schash|
+        schash.instance_eval do
           case type
           when :cart
             def url

--- a/lib/asin/client.rb
+++ b/lib/asin/client.rb
@@ -3,7 +3,7 @@ require 'rexml/document' # https://github.com/phoet/asin/pull/23
 require 'crack/xml'
 require 'cgi'
 require 'base64'
-require 'rash'
+require 'sc_hash'
 
 module ASIN
   module Client
@@ -216,7 +216,7 @@ module ASIN
     end
 
     def handle_type(data, type)
-      Hashie::Rash.new(data)
+      Hashie::SCHash.new(data)
     end
 
     def create_item_params(items)


### PR DESCRIPTION
Hashie::Rash was redefined in version 3.x of the Hashie gem to be a regular expression-based hash.  This replaces Hashie::Rash with a new class, Hashie::SCHash, that includes the old functionality that Hashie::Rash had.

A new Gem was introduced because the old Rash gem is defunct and has been forked by a new maintainer, but it can't be loaded in a Gemspec because of differences between Bundler and how gemspec articulates requirements.  (Gemspec doesn't support github-based paths, specifically.)

```
2.1.5 :012 >   ASIN::Configuration.configure do |config|
2.1.5 :013 >       config.key = ENV['AWS_KEY']
2.1.5 :014?>     config.secret = ENV['AWS_SECRET']
2.1.5 :015?>     config.associate_tag = ENV['AWS_TAG']
2.1.5 :016?>   end
[...]
2.1.5 :022 > item = ASIN::Client.instance.lookup 'B00SSQOJRS'
[...]
2.1.5 :024 > item.first.asin
 => "B00SSQOJRS"
2.1.5 :027 > item.first.class
 => Hashie::SCHash
```

